### PR TITLE
base_sched: Fix regular expressions for perf sched timehist -V

### DIFF
--- a/base_sched/test_timehist.sh
+++ b/base_sched/test_timehist.sh
@@ -163,7 +163,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "--with-summary"
 $CMD_PERF sched timehist -V > $LOGS_DIR/timehist_visual.log 2> /dev/null
 PERF_EXIT_CODE=$?
 
-REGEX_V_HEADER_LINE="\s+time\s+cpu\s+\d+\s+task name\s+wait time\s+sch delay\s+run time"
+REGEX_V_HEADER_LINE="\s+time\s+cpu\s+[\da-f]+\s+task name\s+wait time\s+sch delay\s+run time"
 REGEX_V_DATA_LINE="\s+$RE_NUMBER\s+\[\d+\]\s+s\s+[\w~\[\]\/ \+:#-]+\s+$RE_NUMBER\s+$RE_NUMBER\s+$RE_NUMBER"
 REGEX_V_IDLE_LINE="\s+$RE_NUMBER\s+\[\d+\]\s+i\s+<idle>\s+$RE_NUMBER\s+$RE_NUMBER\s+$RE_NUMBER"
 


### PR DESCRIPTION
The headline in the output of cpu-visual contains a hexadecimal column
rather than a numerical line. Fix the regular expressions to get rid of
false warning.
```
# perf sched timehist -V
Samples do not have callchains.
           time    cpu  0123456789abcdef0  task name                       wait time  sch delay   run time
                                           [tid/pid]                          (msec)     (msec)     (msec)
--------------- ------  -----------------  ------------------------------  ---------  ---------  ---------
   15086.819343 [0006]        i            <idle>                              0.000      0.000      0.000 
```
Signed-off-by: Ziqian SUN (Zamir) <zsun@redhat.com>