### PR TITLE
Devel

### DIFF
--- a/base_mem/test_basic.sh
+++ b/base_mem/test_basic.sh
@@ -234,14 +234,14 @@ fi
 
 # run only if one of previous tests was successfully executed
 if [ -f $CURRENT_TEST_DIR/perf.data ]; then
-	$CMD_PERF script -i $CURRENT_TEST_DIR/perf.data -F "comm,pid,event,weight" > $LOGS_DIR/basic_weight.out 2> $LOGS_DIR/basic_weight.err
+	$CMD_PERF script -i $CURRENT_TEST_DIR/perf.data -F "comm,pid,event,weight" > $LOGS_DIR/basic_weight.log 2> $LOGS_DIR/basic_weight.err
 	PERF_EXIT_CODE=$?
 
 	REGEX_SYMBOL="(?:[\w\.@:<>*~, ]+\+$RE_ADDRESS|\[unknown\])"
 	REGEX_SCRIPT_LINE="\s*[\w\-]+\s+$RE_NUMBER\s+$RE_EVENT_ANY\s+$RE_NUMBER"
-	../common/check_all_patterns_found.pl "$REGEX_SCRIPT_LINE" < $LOGS_DIR/basic_weight.out
+	../common/check_all_patterns_found.pl "$REGEX_SCRIPT_LINE" < $LOGS_DIR/basic_weight.log
 	CHECK_EXIT_CODE=$?
-	../common/check_all_lines_matched.pl "$REGEX_SCRIPT_LINE" < $LOGS_DIR/basic_weight.out
+	../common/check_all_lines_matched.pl "$REGEX_SCRIPT_LINE" < $LOGS_DIR/basic_weight.log
 	(( CHECK_EXIT_CODE += $? ))
 	../common/check_no_patterns_found.pl "event do not have WEIGHT attribute set" "Cannot print" < $LOGS_DIR/basic_weight.err
 	(( CHECK_EXIT_CODE += $? ))

--- a/base_probe/cleanup.sh
+++ b/base_probe/cleanup.sh
@@ -15,7 +15,6 @@ clear_all_probes
 if [ ! -n "$PERFSUITE_RUN_DIR" ]; then
 	find . -name \*.log | xargs -r rm
 	find . -name \*.err | xargs -r rm
-	find . -name \*.out | xargs -r rm
 	rm -f perf.data*
 	make -s -C examples clean
 fi

--- a/base_probe/test_sdt.sh
+++ b/base_probe/test_sdt.sh
@@ -85,7 +85,7 @@ PROBE_PREFIX=`head -n 1 $LOGS_DIR/sdt_list.log | perl -ne 'print "$1" if /\s+(\w
 
 for N in 13 128 241; do
 	# perf stat should catch all the events and give exact results
-	$CMD_PERF stat -x';' -e "$PROBE_PREFIX:"'*' $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_stat_$N.out 2> $LOGS_DIR/sdt_stat_$N.log
+	$CMD_PERF stat -x';' -e "$PROBE_PREFIX:"'*' $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_stat_$N.log 2> $LOGS_DIR/sdt_stat_$N.log
 	PERF_EXIT_CODE=$?
 
 	# check for exact values in perf stat results
@@ -101,7 +101,7 @@ done
 REGEX_SCRIPT_LINE="\s*simple_threads\s+$RE_NUMBER\s+\[$RE_NUMBER\]\s+$RE_NUMBER:\s+sdt_lib\w+:pthread_\w+:\s+\($RE_NUMBER_HEX\)"
 for N in 37 97 237; do
 	# perf record should catch all the samples as well
-	$CMD_PERF record -m 16M -e "$PROBE_PREFIX:"'*' -o $CURRENT_TEST_DIR/perf.data $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_record_$N.out 2> $LOGS_DIR/sdt_record_$N.log
+	$CMD_PERF record -m 16M -e "$PROBE_PREFIX:"'*' -o $CURRENT_TEST_DIR/perf.data $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_record_$N.log 2> $LOGS_DIR/sdt_record_$N.log
 	PERF_EXIT_CODE=$?
 
 	# perf record should catch exactly ($N * $NO_OF_EVENTS_TO_TEST) samples

--- a/base_probe/test_sdt.sh
+++ b/base_probe/test_sdt.sh
@@ -85,11 +85,11 @@ PROBE_PREFIX=`head -n 1 $LOGS_DIR/sdt_list.log | perl -ne 'print "$1" if /\s+(\w
 
 for N in 13 128 241; do
 	# perf stat should catch all the events and give exact results
-	$CMD_PERF stat -x';' -e "$PROBE_PREFIX:"'*' $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_stat_$N.log 2> $LOGS_DIR/sdt_stat_$N.log
+	$CMD_PERF stat -x';' -e "$PROBE_PREFIX:"'*' $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_stat_$N.log 2> $LOGS_DIR/sdt_stat_$N.err
 	PERF_EXIT_CODE=$?
 
 	# check for exact values in perf stat results
-	../common/check_all_lines_matched.pl "$N;+$PROBE_PREFIX:pthread_" < $LOGS_DIR/sdt_stat_$N.log
+	../common/check_all_lines_matched.pl "$N;+$PROBE_PREFIX:pthread_" < $LOGS_DIR/sdt_stat_$N.err
 	CHECK_EXIT_CODE=$?
 
 	print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "using probes :: perf stat (N = $N)"
@@ -101,12 +101,12 @@ done
 REGEX_SCRIPT_LINE="\s*simple_threads\s+$RE_NUMBER\s+\[$RE_NUMBER\]\s+$RE_NUMBER:\s+sdt_lib\w+:pthread_\w+:\s+\($RE_NUMBER_HEX\)"
 for N in 37 97 237; do
 	# perf record should catch all the samples as well
-	$CMD_PERF record -m 16M -e "$PROBE_PREFIX:"'*' -o $CURRENT_TEST_DIR/perf.data $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_record_$N.log 2> $LOGS_DIR/sdt_record_$N.log
+	$CMD_PERF record -m 16M -e "$PROBE_PREFIX:"'*' -o $CURRENT_TEST_DIR/perf.data $CURRENT_TEST_DIR/examples/simple_threads $N > $LOGS_DIR/sdt_record_$N.log 2> $LOGS_DIR/sdt_record_$N.err
 	PERF_EXIT_CODE=$?
 
 	# perf record should catch exactly ($N * $NO_OF_EVENTS_TO_TEST) samples
 	EXPECTED_SAMPLES=$(( N * NO_OF_EVENTS_TO_TEST ))
-	../common/check_all_patterns_found.pl "$RE_LINE_RECORD1" "$RE_LINE_RECORD2" "$EXPECTED_SAMPLES samples" < $LOGS_DIR/sdt_record_$N.log
+	../common/check_all_patterns_found.pl "$RE_LINE_RECORD1" "$RE_LINE_RECORD2" "$EXPECTED_SAMPLES samples" < $LOGS_DIR/sdt_record_$N.err
 	CHECK_EXIT_CODE=$?
 
 	print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "using probes :: perf record (N = $N)"

--- a/base_record/test_basic.sh
+++ b/base_record/test_basic.sh
@@ -96,7 +96,7 @@ fi
 # when perf record detects that stdout is piped, it puts the data there instead of to perf.data
 # when there is '-k mono' option, it used to segfault
 # this testcase tests, whether the segfault is fixed 
-{ $CMD_PERF record -k mono -- true  | cat; } > $LOGS_DIR/basic_kmono_crash.out 2> $LOGS_DIR/basic_kmono_crash.err
+{ $CMD_PERF record -k mono -- true  | cat; } > $LOGS_DIR/basic_kmono_crash.log 2> $LOGS_DIR/basic_kmono_crash.err
 
 ../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_kmono_crash.err
 PERF_EXIT_STATUS=$?
@@ -108,7 +108,7 @@ print_results $PERF_EXIT_STATUS 0 "-k mono crash"
 ### large -C number
 
 # perf used to segfault if a number too large was used with -C
-{ $CMD_PERF record -C 12323431 -- true | cat; } > $LOGS_DIR/basic_largeC_crash.out 2> $LOGS_DIR/basic_largeC_crash.err
+{ $CMD_PERF record -C 12323431 -- true | cat; } > $LOGS_DIR/basic_largeC_crash.log 2> $LOGS_DIR/basic_largeC_crash.err
 
 ../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_largeC_crash.err
 PERF_EXIT_STATUS=$?

--- a/base_record/test_basic.sh
+++ b/base_record/test_basic.sh
@@ -95,8 +95,8 @@ fi
 
 # when perf record detects that stdout is piped, it puts the data there instead of to perf.data
 # when there is '-k mono' option, it used to segfault
-# this testcase tests, whether the segfault is fixed
-sh -c "$CMD_PERF record -k mono -- true | cat" > $LOGS_DIR/basic_kmono_crash.out 2> $LOGS_DIR/basic_kmono_crash.err
+# this testcase tests, whether the segfault is fixed 
+{ $CMD_PERF record -k mono -- true  | cat; } > $LOGS_DIR/basic_kmono_crash.out 2> $LOGS_DIR/basic_kmono_crash.err
 
 ../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_kmono_crash.err
 PERF_EXIT_STATUS=$?
@@ -108,7 +108,7 @@ print_results $PERF_EXIT_STATUS 0 "-k mono crash"
 ### large -C number
 
 # perf used to segfault if a number too large was used with -C
-sh -c "$CMD_PERF record -C 12323431 -- true | cat" > $LOGS_DIR/basic_largeC_crash.out 2> $LOGS_DIR/basic_largeC_crash.err
+{ $CMD_PERF record -C 12323431 -- true | cat; } > $LOGS_DIR/basic_largeC_crash.out 2> $LOGS_DIR/basic_largeC_crash.err
 
 ../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_largeC_crash.err
 PERF_EXIT_STATUS=$?

--- a/base_script/cleanup.sh
+++ b/base_script/cleanup.sh
@@ -18,7 +18,6 @@ if [ -n "$PERFSUITE_RUN_DIR" ]; then
 fi
 
 find . -name \*.log | xargs -r rm
-find . -name \*.out | xargs -r rm
 find . -name \*.err | xargs -r rm
 rm -f perf.data*
 

--- a/base_stat/test_basic.sh
+++ b/base_stat/test_basic.sh
@@ -101,7 +101,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "CSV output"
 # the bug was caused by missing aggr_header_csv for AGGR_NODE and should be fixed
 # this testcase tests, whether the segfault has been fixed
 
-sh -c "$CMD_PERF stat -a --per-node -x, --metric-only true" > $LOGS_DIR/basic_per_node_x_crash.out 2> $LOGS_DIR/basic_per_node_x_crash.err
+{ sh -c "$CMD_PERF stat -a --per-node -x, --metric-only $CMD_SIMPLE"; } > $LOGS_DIR/basic_per_node_x_crash.out 2> $LOGS_DIR/basic_per_node_x_crash.err
 
 ../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_per_node_x_crash.err
 PERF_EXIT_STATUS=$?

--- a/base_stat/test_basic.sh
+++ b/base_stat/test_basic.sh
@@ -101,7 +101,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "CSV output"
 # the bug was caused by missing aggr_header_csv for AGGR_NODE and should be fixed
 # this testcase tests, whether the segfault has been fixed
 
-{ sh -c "$CMD_PERF stat -a --per-node -x, --metric-only $CMD_SIMPLE"; } > $LOGS_DIR/basic_per_node_x_crash.out 2> $LOGS_DIR/basic_per_node_x_crash.err
+{ $CMD_PERF stat -a --per-node -x, --metric-only $CMD_SIMPLE; } > $LOGS_DIR/basic_per_node_x_crash.out 2> $LOGS_DIR/basic_per_node_x_crash.err
 
 ../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_per_node_x_crash.err
 PERF_EXIT_STATUS=$?

--- a/base_stat/test_basic.sh
+++ b/base_stat/test_basic.sh
@@ -101,7 +101,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "CSV output"
 # the bug was caused by missing aggr_header_csv for AGGR_NODE and should be fixed
 # this testcase tests, whether the segfault has been fixed
 
-{ $CMD_PERF stat -a --per-node -x, --metric-only $CMD_SIMPLE; } > $LOGS_DIR/basic_per_node_x_crash.out 2> $LOGS_DIR/basic_per_node_x_crash.err
+{ $CMD_PERF stat -a --per-node -x, --metric-only $CMD_SIMPLE; } > $LOGS_DIR/basic_per_node_x_crash.log 2> $LOGS_DIR/basic_per_node_x_crash.err
 
 ../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_per_node_x_crash.err
 PERF_EXIT_STATUS=$?

--- a/base_stat/test_basic.sh
+++ b/base_stat/test_basic.sh
@@ -96,6 +96,21 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "CSV output"
 (( TEST_RESULT += $? ))
 
 
+### BUG: perf stat -a --per-node -x, --metric-only true command crashes
+
+# the bug was caused by missing aggr_header_csv for AGGR_NODE and should be fixed
+# this testcase tests, whether the segfault has been fixed
+
+sh -c "$CMD_PERF stat -a --per-node -x, --metric-only true" > $LOGS_DIR/basic_per_node_x_crash.out 2> $LOGS_DIR/basic_per_node_x_crash.err
+
+../common/check_no_patterns_found.pl "Segmentation fault" "SIGSEGV" "core" "dumped" "segfault" < $LOGS_DIR/basic_per_node_x_crash.err
+PERF_EXIT_STATUS=$?
+
+print_results $PERF_EXIT_STATUS 0 "--per-node -x crash"
+(( TEST_RESULT += $? ))
+
+
+
 # print overall results
 print_overall_results "$TEST_RESULT"
 exit $?

--- a/base_version/cleanup.sh
+++ b/base_version/cleanup.sh
@@ -17,7 +17,7 @@ if [ -n "$PERFSUITE_RUN_DIR" ]; then
 	exit 0
 fi
 
-find . -name \*.out | xargs -r rm
+find . -name \*.log | xargs -r rm
 find . -name \*.err | xargs -r rm
 
 print_overall_results 0

--- a/base_version/test_basic.sh
+++ b/base_version/test_basic.sh
@@ -36,7 +36,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "basic execution"
 #### invalid option
 
 # BUG: perf version crashes with an invalid option
-{ sh -c "$CMD_PERF version -t"; } > $LOGS_DIR/basic_invalid_opt.out 2> $LOGS_DIR/basic_invalid_opt.err
+{ sh -c "$CMD_PERF version -t"; } > $LOGS_DIR/basic_invalid_opt.log 2> $LOGS_DIR/basic_invalid_opt.err
 test $? -ne 139
 PERF_EXIT_CODE=$?
 


### PR DESCRIPTION
Testcase for the already fixed bug resulting in segfault was added to base_stat/test_basic.sh. It was later fixed together with the test in base_record/test_basic.sh, as both weren't correctly capturing the segfault message. Finally, the output files for the stdout was changed to .log only. This change may cause further unwanted changes as other output files for stderr were set to .log files too and a review would be recommended.