### PR TITLE
base_stat/test_pmu.sh: Fix parsing of pmu events

### DIFF
--- a/base_stat/test_pmu.sh
+++ b/base_stat/test_pmu.sh
@@ -21,7 +21,7 @@ if [ ! "$PARAM_STAT_ALL_PMU_EVENTS" == "y" ]; then
 	exit 0
 fi
 
-EVENTS_TO_TEST=`$CMD_PERF list --no-desc pmu | grep "Kernel PMU event" | grep -v -e uncore -e offcore -e msr -e '//' -e '?' -e hv_gpci | awk '{print $1}' | egrep '^.' | tr '\n' ' '`
+EVENTS_TO_TEST=`$CMD_PERF list --no-desc pmu | grep "Kernel PMU event" | grep -v -e uncore -e offcore -e msr -e '//' -e '?' -e hv_gpci | sed -r 's/\[/ /g' | awk '{print $1}' | egrep '^.' | tr '\n' ' '`
 if [ -z "$EVENTS_TO_TEST" ]; then
 	if [ "$TEST_IGNORE_MISSING_PMU" = "y" ]; then
 		print_overall_skipped


### PR DESCRIPTION
To correctly parse pmu events it was expected that there is a space character between the name of the event and its description. But this is not true if the events are so long that for the given formatting no more spaces are added.

Fix this issue by replacing the first character of the kernel pmu event description with space for the parsing to work correctly.