### PR TITLE
base_annotate/test_basic.sh: use "--objdump" to show the C code

### DIFF
--- a/base_annotate/test_basic.sh
+++ b/base_annotate/test_basic.sh
@@ -46,7 +46,7 @@ fi
 ### basic execution
 
 # annotate...
-$CMD_PERF annotate -i $CURRENT_TEST_DIR/perf.data --stdio > $LOGS_DIR/basic_annotate.log 2> $LOGS_DIR/basic_annotate.err
+$CMD_PERF annotate --objdump `which objdump` -i $CURRENT_TEST_DIR/perf.data --stdio > $LOGS_DIR/basic_annotate.log 2> $LOGS_DIR/basic_annotate.err
 PERF_EXIT_CODE=$?
 
 # check the annotate output; default option means both source and assembly
@@ -67,7 +67,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "basic execution - annotate"
 ### dso filter
 
 # '--dso SOME_DSO' limits the annotation to SOME_DSO only
-$CMD_PERF annotate -i $CURRENT_TEST_DIR/perf.data --stdio --dso load > $LOGS_DIR/basic_dso.log 2> $LOGS_DIR/basic_dso.err
+$CMD_PERF annotate --objdump `which objdump` -i $CURRENT_TEST_DIR/perf.data --stdio --dso load > $LOGS_DIR/basic_dso.log 2> $LOGS_DIR/basic_dso.err
 PERF_EXIT_CODE=$?
 
 ../common/check_all_patterns_found.pl "$REGEX_HEADER load" "$REGEX_LINE" "$REGEX_SECTION__TEXT" < $LOGS_DIR/basic_dso.log
@@ -86,7 +86,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "dso filter"
 ### no-source
 
 # '--no-source' should show only the assembly code
-$CMD_PERF annotate -i $CURRENT_TEST_DIR/perf.data --stdio --no-source --dso load > $LOGS_DIR/basic_nosource.log 2> $LOGS_DIR/basic_nosource.err
+$CMD_PERF annotate --objdump `which objdump` -i $CURRENT_TEST_DIR/perf.data --stdio --no-source --dso load > $LOGS_DIR/basic_nosource.log 2> $LOGS_DIR/basic_nosource.err
 PERF_EXIT_CODE=$?
 
 ../common/check_all_patterns_found.pl "$REGEX_HEADER load" "$REGEX_LINE" "$REGEX_SECTION__TEXT" < $LOGS_DIR/basic_nosource.log
@@ -105,7 +105,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "no-source"
 ### full-paths
 
 # '-P' should print full paths of DSOs
-$CMD_PERF annotate -i $CURRENT_TEST_DIR/perf.data --stdio --dso load -P > $LOGS_DIR/basic_fullpaths.log 2> $LOGS_DIR/basic_fullpaths.err
+$CMD_PERF annotate --objdump `which objdump` -i $CURRENT_TEST_DIR/perf.data --stdio --dso load -P > $LOGS_DIR/basic_fullpaths.log 2> $LOGS_DIR/basic_fullpaths.err
 PERF_EXIT_CODE=$?
 
 FULLPATH=`readlink -f $CURRENT_TEST_DIR/examples`
@@ -119,7 +119,7 @@ print_results $PERF_EXIT_CODE $CHECK_EXIT_CODE "full-paths"
 ### print-line
 
 # '--print-line' should print inline the source lines
-$CMD_PERF annotate -i $CURRENT_TEST_DIR/perf.data --stdio --dso load -P --print-line > $LOGS_DIR/basic_printline.log 2> $LOGS_DIR/basic_printline.err
+$CMD_PERF annotate --objdump `which objdump` -i $CURRENT_TEST_DIR/perf.data --stdio --dso load -P --print-line > $LOGS_DIR/basic_printline.log 2> $LOGS_DIR/basic_printline.err
 PERF_EXIT_CODE=$?
 
 FULLPATH="`pwd`/examples"


### PR DESCRIPTION
Since kernel v6.10(commit 6d17edc113de1e21fc66afa76be475a4f7c91826),
libcapstone as a default tool to disassemble code, but it will not show
all C code information. Use "--objdump" option to resolve this problem.

Test passed on v6.12 kernel and 5.14 kernel.